### PR TITLE
Debugged potential libgl.so.1 not found error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,12 @@ __pycache__/
 # C extensions
 #*.so
 
+# Don't commit downloaded dataset:
+/1_prepare_data/data
+
+# Make sure to download the latest version from TF Object Detection:
+/1_prepare_data/docker/code/utils/dataset_util.py
+
 # Distribution / packaging
 .Python
 build/

--- a/1_prepare_data/docker/build_and_push.sh
+++ b/1_prepare_data/docker/build_and_push.sh
@@ -44,3 +44,6 @@ docker tag ${image} ${fullname}
 
 echo "Pushing image to ECR ${fullname}"
 docker push ${fullname}
+
+# Writing the image name to let the calling process extract it without manual intervention:
+echo "${fullname}" > ecr_image_fullname.txt

--- a/1_prepare_data/prepare_data.ipynb
+++ b/1_prepare_data/prepare_data.ipynb
@@ -25,7 +25,8 @@
     "!pip install -q --upgrade pip\n",
     "!pip install -q sagemaker==2.16.2\n",
     "!pip install -q jsonlines\n",
-    "# get dataset_util file from TF2 Object Detection Gitub repository\n",
+    "\n",
+    "# Get dataset_util file from TF2 Object Detection GitHub repository\n",
     "!wget -P ./docker/code/utils https://raw.githubusercontent.com/tensorflow/models/master/research/object_detection/utils/dataset_util.py"
    ]
   },
@@ -232,8 +233,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Replace by your ECR image uri\n",
-    "container = '<your-container-image-uri>'"
+    "# Get the ECR image uri\n",
+    "with open (os.path.join('docker', 'ecr_image_fullname.txt'), 'r') as f:\n",
+    "    container = f.readlines()[0][:-1]\n",
+    "    \n",
+    "print(container)"
    ]
   },
   {
@@ -292,13 +296,6 @@
     "    ]\n",
     ")"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -321,5 +318,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }

--- a/2_train_model/docker/Dockerfile
+++ b/2_train_model/docker/Dockerfile
@@ -11,6 +11,9 @@ RUN apt-get update && apt-get install -y \
     python3-pil \
     python3-lxml \
     python3-tk \
+    ffmpeg \
+    libsm6 \
+    libxext6 \
     wget
 
 # Copy this version of of the model garden into the image

--- a/2_train_model/docker/build_and_push.sh
+++ b/2_train_model/docker/build_and_push.sh
@@ -44,3 +44,6 @@ docker tag ${image} ${fullname}
 
 echo "Pushing image to ECR ${fullname}"
 docker push ${fullname}
+
+# Writing the image name to let the calling process extract it without manual intervention:
+echo "${fullname}" > ecr_image_fullname.txt

--- a/2_train_model/train_model.ipynb
+++ b/2_train_model/train_model.ipynb
@@ -42,7 +42,8 @@
    "outputs": [],
    "source": [
     "!git clone https://github.com/tensorflow/models.git docker/models\n",
-    "# get model_main and exporter_main files from TF2 Object Detection Gitub repository\n",
+    "    \n",
+    "# get model_main and exporter_main files from TF2 Object Detection GitHub repository\n",
     "!wget -P ./source_dir https://raw.githubusercontent.com/tensorflow/models/master/research/object_detection/exporter_main_v2.py\n",
     "!wget -P ./source_dir https://raw.githubusercontent.com/tensorflow/models/master/research/object_detection/model_main_tf2.py"
    ]
@@ -73,7 +74,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "container = '<your-container-image-uri>'"
+    "with open (os.path.join('docker', 'ecr_image_fullname.txt'), 'r') as f:\n",
+    "    container = f.readlines()[0][:-1]\n",
+    "    \n",
+    "print(container)"
    ]
   },
   {
@@ -91,7 +95,7 @@
    },
    "outputs": [],
    "source": [
-    "#Download the base model and extract locally\n",
+    "# Download the base model and extract locally\n",
     "!mkdir /tmp/checkpoint\n",
     "!mkdir source_dir/checkpoint\n",
     "!wget -O /tmp/efficientdet.tar.gz http://download.tensorflow.org/models/object_detection/tf2/20200711/efficientdet_d0_coco17_tpu-32.tar.gz\n",
@@ -214,32 +218,6 @@
     "tensorboard_s3_output_path = f'{job_artifacts_path}/train'\n",
     "!F_CPP_MIN_LOG_LEVEL=3 AWS_REGION=eu-west-1 tensorboard --logdir=$tensorboard_s3_output_path"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#tensorboard_s3_output_path = f'{job_artifacts_path}/eval' \n",
-    "#!F_CPP_MIN_LOG_LEVEL=3 AWS_REGION=eu-west-1 tensorboard --logdir=$tensorboard_s3_output_path"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# !F_CPP_MIN_LOG_LEVEL=3 AWS_REGION=eu-west-1 tensorboard --inspect --logdir $tensorboard_s3_output_path"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
… image push to ECR.

*Issue #, if available:*

*Description of changes:*
- I had a libgl.so.1 library not found error when training the model. Updating the training docker script to add the following libraries helped: ffmpeg, libsm6, libxext6.
- Also, added an ECR image output to a text file at the end of the build_and_push.sh scripts to allow the calling notebooks to read the ECR image ID directly from this file instead of asking the reader to manually enter it.
- A few typos

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
