### PR TITLE
Update prepare_data.ipynb

### DIFF
--- a/1_prepare_data/prepare_data.ipynb
+++ b/1_prepare_data/prepare_data.ipynb
@@ -278,6 +278,7 @@
     "        f'--input={input_folder}',\n",
     "        f'--ground_truth_manifest={ground_truth_manifest}',\n",
     "        f'--label_map={label_map}',\n",
+    "        f'--labeling_job={labeling_job_name}',
     "        f'--output={output_folder}'\n",
     "    ],\n",
     "    inputs = [\n",


### PR DESCRIPTION
Labeling Job Argument added
*Issues* 
```bash
Traceback (most recent call last):
  File "/opt/program/prepare_data.py", line 30, in <module>
    tf_record_generator.generate_tf_records()
  File "/opt/program/utils/tf_record_util.py", line 30, in generate_tf_records
    annotation_dict[self.label_job]['annotations'])
KeyError: None
```
*Description of changes:*
 The document was missing the labeling job argument for generating TF Record and It was showing an error. Fixed it by adding 

```python
f'--labeling_job={labeling_job_name}'
```
