### PR TITLE
Update Dockerfile to address nvidia-docker #1632

### DIFF
--- a/1_prepare_data/docker/Dockerfile
+++ b/1_prepare_data/docker/Dockerfile
@@ -3,6 +3,10 @@ FROM tensorflow/tensorflow:2.2.0-gpu
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install apt dependencies
+RUN apt-key del 7fa2af80
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/machine-learning/repos/ubuntu2004/x86_64/7fa2af80.pub
+# Adding the above 3 lines to workaround a recent issue introduced by NVIDIA https://github.com/NVIDIA/nvidia-docker/issues/1632
 RUN apt-get update && apt-get install -y \
     git \
     gpg-agent \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The docker image build fails with gpg key error as noted here https://github.com/NVIDIA/nvidia-container-toolkit/issues/257


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
