### PR TITLE
Adding two options for kernels/envs to choose

### DIFF
--- a/0_set_up_env/requirements.txt
+++ b/0_set_up_env/requirements.txt
@@ -8,10 +8,11 @@ Pillow==9.0.1
 opencv-python==4.6.0.66
 matplotlib==3.5.2
 matplotlib-inline==0.1.3
-tensorboard==2.9.1
 tensorboard-data-server==0.6.1
 tensorboard-plugin-wit==1.8.1
 tensorflow==2.9.0
 tensorflow-estimator==2.9.0
 tensorflow-io==0.26.0
 tensorflow-io-gcs-filesystem==0.26.0
+ipykernel==6.15.0
+ipython==7.34.0

--- a/0_set_up_env/setup-conda-env.sh
+++ b/0_set_up_env/setup-conda-env.sh
@@ -1,0 +1,6 @@
+#sh setup-conda-env.sh envname
+env_name=$1
+conda create -n "${env_name}" python=3.7.11 -y
+source activate "${env_name}" 
+pip install -r requirements.txt
+python -m ipykernel install --user --name "${env_name}" --display-name "${env_name}"

--- a/1_prepare_data/prepare_data.ipynb
+++ b/1_prepare_data/prepare_data.ipynb
@@ -20,7 +20,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Make sure you have the necessary libraries installed, see 0_set_up_env.\n",
+    "#If you're using an Amazon SageMaker Notebook instance, please select the \"conda_tensorflow2_p36\" kernel.\n",
+    "#If you're using anything else feel free to make use of the script in 0_set_up_env folder and select the custom kernel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install -q --upgrade pip\n",
+    "!pip install -q sagemaker==2.96.0\n",
+    "!pip install -q jsonlines\n",
     "# Get dataset_util file from TF2 Object Detection GitHub repository\n",
     "!wget -P ./docker/code/utils https://raw.githubusercontent.com/tensorflow/models/master/research/object_detection/utils/dataset_util.py"
    ]
@@ -304,9 +316,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myenv",
+   "display_name": "conda_tensorflow2_p36",
    "language": "python",
-   "name": "myenv"
+   "name": "conda_tensorflow2_p36"
   },
   "language_info": {
    "codemirror_mode": {
@@ -318,7 +330,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/2_train_model/train_model.ipynb
+++ b/2_train_model/train_model.ipynb
@@ -222,6 +222,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#Due to this issue: https://github.com/ipython/ipykernel/issues/395#issuecomment-479787997\n",
+    "#If you're using a custom conda env, there is a change that the tensorboard executable isn't in the Python path.\n",
+    "#uncomment the following lines\n",
+    "\n",
+    "#bin_env_path = \"/home/ec2-user/anaconda3/envs/myenv/bin/\"\n",
+    "#os.environ[\"PATH\"] += os.pathsep + bin_env_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "job_artifacts_path = estimator.latest_job_tensorboard_artifacts_path()\n",
     "job_artifacts_path"
    ]
@@ -265,9 +279,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "myenv",
+   "display_name": "conda_tensorflow2_p36",
    "language": "python",
-   "name": "myenv"
+   "name": "conda_tensorflow2_p36"
   },
   "language_info": {
    "codemirror_mode": {
@@ -279,7 +293,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.11"
+   "version": "3.6.13"
   }
  },
  "nbformat": 4,

--- a/README.md
+++ b/README.md
@@ -17,15 +17,13 @@ Clone this repository into your Amazon SageMaker notebook instance:
 git clone https://github.com/aws-samples/amazon-sagemaker-tensorflow-object-detection-api.git
 ```
 
-Use the 0_set_up_env to set up a conda env with the necassry libraries.
-This is to ensure the imports in the notebooks are working, the libraries used in the processing, training, deployement components are managed through docker containers.
-If you have your own personal environement, feel free to skip but take a look at the 0_set_up_env/requirements.txt to know what to expect.
 
 ### Instructions
 You will use an example dataset from the [inaturalist.org](http://inaturalist.org/) and train a Tensorflow Object Detection model to recognise bees from RGB images.
 This dataset contains 500 images of bees that have been uploaded by inaturalist users for the purposes of recording the observation and identification. We only used images that their users have licensed under [CC0](https://creativecommons.org/share-your-work/public-domain/cc0/) license.
 
 Follow the step-by-step guide by executing the notebooks in the following folders:
+* [Optional] 0_set_up_env/setup-conda-env.sh
 * 1_prepare_data/prepare_data.ipynb
 * 2_train_model/train_model.ipynb
 * 3_predict/deploy_endpoint.ipynb


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding the possibility to either choose kernel from Amazon SageMaker Notebook instances or building your own.
Adding tensorboard bin path to the PYTHON path when using custom kernels.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
